### PR TITLE
Stop the Cross section box from clipping its own title

### DIFF
--- a/src/segfix/widgets.py
+++ b/src/segfix/widgets.py
@@ -46,6 +46,20 @@ from .viewer import (
 )
 
 
+def _fit_group_title(box: QGroupBox) -> None:
+    """Keep a group box at least wide enough to draw its whole title.
+
+    A ``QGroupBox`` laid out in a horizontal strip is sized from its
+    *contents*.  When the title is wider than the controls inside it — as
+    with the short ``[On] [Slab…]`` row under "Cross section (C)" — Qt sizes
+    the box to the contents and clips the title, so the user sees
+    "Cross section (C" with the ")" cut off.  Raise the minimum width to the
+    title's own width plus the frame and title insets the style adds.
+    """
+    fm = box.fontMetrics()
+    box.setMinimumWidth(fm.horizontalAdvance(box.title()) + 30)
+
+
 class SegFixController:
     """Holds the editable cloud + napari layer and applies operations."""
 
@@ -348,6 +362,7 @@ class SegFixWidget(QWidget):
         slab_btn.clicked.connect(
             lambda: self._toggle_popover(self._cross_popover, slab_btn)
         )
+        _fit_group_title(self.cross_box)
         top_bar_row.addWidget(self.cross_box)
         self._cross_lo, self._cross_hi = 0.0, 1.0
         self._reset_cross_section_range()
@@ -389,6 +404,7 @@ class SegFixWidget(QWidget):
         lsec.addWidget(section_reset_btn)
         self.lasso_section_label = QLabel(self)  # not shown; feeds the tooltip
         self.lasso_section_label.hide()
+        _fit_group_title(self.lasso_section_box)
         top_bar_row.addWidget(self.lasso_section_box)
         self._lasso_section_mask: np.ndarray | None = None
         self._update_lasso_section_label()


### PR DESCRIPTION
## Problem

In the top toolbar the `Cross section (C)` group box renders as `Cross section (C` — the closing paren is cut off. This happens at any window size (reproduced on a 1900px-wide window), so it is not a toolbar-overflow issue.

## Cause

A `QGroupBox` laid out in a horizontal strip is sized to its **contents**. The `[On] [Slab…]` row is ~115px wide, narrower than the title text (~125px), so Qt draws the title only up to the box's right frame edge and clips it.

`Lasso section (Shift+C)` avoids this only because its `[On] [Draw] [Reset]` row is wider than its title.

## Fix

Add `_fit_group_title()`, which raises a box's minimum width to its title width plus the style's frame/title insets, and apply it to both section boxes. Verified in the running app: the Cross section box grows 115px → 153px and the full title shows. All 53 tests pass.